### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   scanning:
     name: GitGuardian scan
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/tetzng/dotfiles/security/code-scanning/1](https://github.com/tetzng/dotfiles/security/code-scanning/1)

To fix the problem, we need to explicitly add a `permissions` block to restrict the GITHUB_TOKEN permissions for this workflow/job to the minimum required, which is `contents: read`. This should be done at the job level for the `scanning` job (line 6 onwards for clarity), since there is only one job and no other specific permission needed for steps like checkout and running the GitGuardian scan. Add the following under the job definition (`scanning:`), right after its `name:` field (after line 7), before `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
